### PR TITLE
added spaces

### DIFF
--- a/src/lasair-webapp/lasair/lasair/query_builder.py
+++ b/src/lasair-webapp/lasair/lasair/query_builder.py
@@ -206,11 +206,11 @@ def build_query(select_expression, from_expression, where_condition):
     sql += select_expression
 
     # FROM these tables
-    sql += '\nFROM ' + ', '.join(from_table_list)
+    sql += ' \nFROM ' + ', '.join(from_table_list)
 
     # The WHERE clauses
     if len(where_clauses) > 0:
-        sql += '\nWHERE\n' + ' AND\n'.join(where_clauses) + order_condition
+        sql += ' \nWHERE\n ' + ' AND\n '.join(where_clauses) + order_condition
 
     return sql
 


### PR DESCRIPTION
I spent this morning fixing the problems seen by Yael, Iair's student. 

When the query-builder converts the form fields to real SQL it uses both space and newline to separate keywords FROM, WHERE, AND from the rest of the text. For some reason the stored queries made by Yael do not have the newline delimiter and so fail. I don't know what happened to the newline. 

Anyway, I added a space to each newline in the code. And fixed Yael's queries by adding newlines.