### PR TITLE
Feature/topic refresh

### DIFF
--- a/ansible/webserver.yml
+++ b/ansible/webserver.yml
@@ -120,6 +120,11 @@
           executable: pip3 
           name: astropy
 
+    - name: install confluent kafka
+      pip: 
+          executable: pip3 
+          name: confluent_kafka
+
     - name: install cassandra client
       pip:
           executable: pip3 

--- a/src/lasair-webapp/lasair/lasair/queries.py
+++ b/src/lasair-webapp/lasair/lasair/queries.py
@@ -296,7 +296,7 @@ def handle_myquery(request, mq_id=None):
             if myquery.active == 2:
                 message += topic_refresh(myquery.real_sql, tn, limit=10)
 
-            message += 'Query updated: %s<br/>' % myquery.name
+            message += 'Query %s updated<br/>' % myquery.name
 
         myquery.save()
         return render(request, 'queryform.html',{

--- a/src/lasair-webapp/lasair/lasair/settings.py.j2
+++ b/src/lasair-webapp/lasair/lasair/settings.py.j2
@@ -22,6 +22,9 @@ READWRITE_PASS = '{{ settings.master_db_password }}'
 DB_HOST        = '{{ settings.master_db_ip }}'
 DB_PORT        = 3306
 
+KAFKA_PRODUCER   = 'kafka-pub:29092'
+KAFKA_PASSWORD   = '{{ settings.kafka_password }}'
+
 DATA_UPLOAD_MAX_MEMORY_SIZE = 26214400
 
 # SECURITY WARNING: keep the secret key used in production secret!

--- a/src/lasair-webapp/lasair/lasair/templates/queryform.html
+++ b/src/lasair-webapp/lasair/lasair/templates/queryform.html
@@ -6,8 +6,6 @@
 <script src="/lasair/static/js/query.js"></script>
 
 <div class="row">
-	<!-- <div class="col-lg"> -->
-<!--	{{ message }} -->
 <h3>Query Builder</h3>
 The form below is a builder for SQL SELECT queries on the ZTF database of objects. 
 If you are logged in to Lasair, you can name and save your query, 
@@ -237,6 +235,7 @@ function ConfirmDelete()
 {% endif %} <!-- logged_in and not new -->
 </tr></table>
 
+<font color='green'>{{ message | safe}}</font>
 </div>
 
 <script type="text/javascript">

--- a/src/lasair-webapp/lasair/lasair/templates/queryform.html
+++ b/src/lasair-webapp/lasair/lasair/templates/queryform.html
@@ -6,6 +6,8 @@
 <script src="/lasair/static/js/query.js"></script>
 
 <div class="row">
+<font color='green'>{{ message | safe}}</font>
+<hr/>
 <h3>Query Builder</h3>
 The form below is a builder for SQL SELECT queries on the ZTF database of objects. 
 If you are logged in to Lasair, you can name and save your query, 
@@ -186,12 +188,23 @@ The SQL <b><font color="red">WHERE</font></b>. Which objects to return. See list
 <input name='page'       type='hidden' value=0>
 {% endif %} <!-- not new and not is_owner -->
 
+<script>
+function ConfirmDelete()
+{
+  confirm("Are you sure you want to delete?");
+}
+function ConfirmSave()
+{
+  confirm("This will empty the stream log and replace the kafka topic with 10 alerts from the past. Continue?");
+}
+</script>
+
 <table border=1 cellpadding=30><tr>
 <!-- SAVE QUERY -->
 {% if newandloggedin or is_owner %}
 <td>
 <input type="submit" class="button" style="color: blue; background-color: #EEEEFF;" 
-{% if new %} value=" Create query" {% else %} value=" Save this Query" {% endif %} >
+value=" Save query" value=" Save this Query" Onclick="ConfirmSave()">
 </td>
 {% endif %} <!-- newandloggedin or is_owner -->
 
@@ -208,12 +221,6 @@ The SQL <b><font color="red">WHERE</font></b>. Which objects to return. See list
 <!-- DELETE QUERY -->
 {% if not new %}
 <td>
-<script>
-function ConfirmDelete()
-{
-  confirm("Are you sure you want to delete?");
-}
-</script>
 <form method="POST"  action="/query/{{ myquery.mq_id }}/">
 {% csrf_token %}
 <input type="hidden" name="delete" value="delete">
@@ -235,7 +242,6 @@ function ConfirmDelete()
 {% endif %} <!-- logged_in and not new -->
 </tr></table>
 
-<font color='green'>{{ message | safe}}</font>
 </div>
 
 <script type="text/javascript">

--- a/src/lasair-webapp/lasair/lasair/topic_refresh.py
+++ b/src/lasair-webapp/lasair/lasair/topic_refresh.py
@@ -1,0 +1,73 @@
+import os
+import json
+import lasair.settings
+from datetime import datetime
+import mysql.connector
+from confluent_kafka import Producer, KafkaError, admin
+
+def connect_db():
+    """connect_db.
+    """
+    msl = mysql.connector.connect(
+        user    =lasair.settings.READONLY_USER,
+        password=lasair.settings.READONLY_PASS,
+        host    =lasair.settings.DATABASES['default']['HOST'],
+        port    =lasair.settings.DATABASES['default']['PORT'],
+        database='ztf')
+    return msl
+
+def datetime_converter(o):
+# used by json encoder when it gets a type it doesn't understand
+    if isinstance(o, datetime.datetime):
+        return o.__str__()
+
+def topic_refresh(real_sql, topic, limit=10):
+    message = ''
+    msl = connect_db()
+    cursor = msl.cursor(buffered=True, dictionary=True)
+    query = real_sql + ' LIMIT %d' % limit
+
+    try:
+        cursor.execute(query)
+    except Exception as e:
+        message += 'Your query:<br/><b>' + query + '</b><br/>returned the error<br/><i>' + str(e) + '</i><br/>'
+        return message
+
+    recent = []
+    for record in cursor:
+        recorddict = dict(record)
+        now_number = datetime.utcnow()
+        recorddict['UTC'] = now_number.strftime("%Y-%m-%d %H:%M:%S")
+        print(recorddict)
+        recent.append(recorddict)
+
+    conf = {
+        'bootstrap.servers': lasair.settings.KAFKA_PRODUCER,
+        'security.protocol': 'SASL_PLAINTEXT',
+        'sasl.mechanisms'  : 'SCRAM-SHA-256',
+        'sasl.username'    : 'admin',
+        'sasl.password'    : lasair.settings.KAFKA_PASSWORD
+    }
+
+    # delete the old topic
+    a = admin.AdminClient(conf)
+
+    try:
+        result = a.delete_topics([topic])
+        result[topic].result()
+        time.sleep(1)
+    except Exception as e:
+        message += 'Topic is ' + topic + '<br/>'
+        message += str(e) + '<br/>'
+
+    # pushing in new messages will remake the topic
+    try:
+        p = Producer(conf)
+        for out in recent: 
+            jsonout = json.dumps(out, default=datetime_converter)
+            p.produce(topic, value=jsonout)
+        p.flush(10.0)   # 10 second timeout
+        message += 'New messages produced to Kafka<br/>'
+    except Exception as e:
+        message += "ERROR in queries/topic_refresh: cannot produce to public kafka<br/>" + str(e) + '<br/>'
+    return message

--- a/src/lasair-webapp/lasair/lasair/topic_refresh.py
+++ b/src/lasair-webapp/lasair/lasair/topic_refresh.py
@@ -1,4 +1,5 @@
 import os
+import time
 import json
 import lasair.settings
 from datetime import datetime
@@ -67,7 +68,7 @@ def topic_refresh(real_sql, topic, limit=10):
             jsonout = json.dumps(out, default=datetime_converter)
             p.produce(topic, value=jsonout)
         p.flush(10.0)   # 10 second timeout
-        message += 'New messages produced to Kafka<br/>'
+        message += 'New messages produced to topic %s<br/>' % topic
     except Exception as e:
         message += "ERROR in queries/topic_refresh: cannot produce to public kafka<br/>" + str(e) + '<br/>'
     return message

--- a/src/lasair-webapp/lasair/lasair/topic_refresh.py
+++ b/src/lasair-webapp/lasair/lasair/topic_refresh.py
@@ -57,6 +57,7 @@ def topic_refresh(real_sql, topic, limit=10):
         result = a.delete_topics([topic])
         result[topic].result()
         time.sleep(1)
+        message += 'Topic %s deleted<br/>' % topic
     except Exception as e:
         message += 'Topic is ' + topic + '<br/>'
         message += str(e) + '<br/>'
@@ -68,7 +69,7 @@ def topic_refresh(real_sql, topic, limit=10):
             jsonout = json.dumps(out, default=datetime_converter)
             p.produce(topic, value=jsonout)
         p.flush(10.0)   # 10 second timeout
-        message += 'New messages produced to topic %s<br/>' % topic
+        message += '%d new messages produced to topic %s<br/>' % (limit, topic)
     except Exception as e:
         message += "ERROR in queries/topic_refresh: cannot produce to public kafka<br/>" + str(e) + '<br/>'
     return message


### PR DESCRIPTION
When a query has active=2, it means it is pushing kafka into a stream. In this case, whenever it is saved or copied, its kafka stream is deleted then remade with 10 rows from the database, and also the streamlog is emptied. For inactive queries (active=0) nothing happens. For email push (active=1), only the stream log is emptied.

Before saving, the user is asked to confirm: "This will empty the stream log and replace the kafka topic with 10 alerts from the past. Continue?"

After saving, the green message at the top of the query form says:
  Topic lasair_2Query-290 deleted
  10 new messages produced to topic lasair_2Query-290
  Query Query-290 updated