### PR TITLE
Fast annotations

### DIFF
--- a/src/lasair-webapp/lasair/lasair/areas.py
+++ b/src/lasair-webapp/lasair/lasair/areas.py
@@ -8,7 +8,7 @@ import lasair.settings
 from lasair.models import Areas, AreaHits
 import mysql.connector
 import json
-import random
+from random import randrange
 from subprocess import Popen, PIPE
 import time
 import base64
@@ -79,7 +79,7 @@ def make_image_of_MOC(fits_bytes):
 
 def area_new(request):
     return render(request, 'area_new.html',
-        {'random': '%d'%random.randrange(1000),
+        {'random': '%d'%randrange(1000),
         'authenticated': request.user.is_authenticated
         })
 
@@ -128,7 +128,7 @@ def areas_home(request):
 
     return render(request, 'areas_home.html',
         {'my_areas': my_areas, 
-        'random': '%d'%random.randrange(1000),
+        'random': '%d'%randrange(1000),
         'other_areas': other_areas, 
         'authenticated': request.user.is_authenticated,
         'message': message})
@@ -152,8 +152,8 @@ def show_area_file(request, ar_id):
 
     moc = string2bytes(area.moc)
 
-    filename = area.name + '.fits'
-    f = open('/home/ubuntu/tmp/blah.fits', 'wb')
+    filename = area.name + '%d.fits'%randrange(1000)
+    f = open('/home/ubuntu/tmp/%s' % filename, 'wb')
     f.write(moc)
     f.close()
 

--- a/src/lasair-webapp/lasair/lasair/settings.py.j2
+++ b/src/lasair-webapp/lasair/lasair/settings.py.j2
@@ -20,7 +20,7 @@ READWRITE_USER = '{{ settings.master_db_username }}'
 READWRITE_PASS = '{{ settings.master_db_password }}'
 
 DB_HOST        = '{{ settings.master_db_ip }}'
-DB_PORT        = 3306
+DB_PORT        =  {{ settings.master_db_port }}
 
 PUBLIC_KAFKA_PRODUCER   = 'kafka-pub:29092'
 PUBLIC_KAFKA_PASSWORD   = '{{ settings.kafka_password }}'

--- a/src/lasair-webapp/lasair/lasair/settings.py.j2
+++ b/src/lasair-webapp/lasair/lasair/settings.py.j2
@@ -22,8 +22,11 @@ READWRITE_PASS = '{{ settings.master_db_password }}'
 DB_HOST        = '{{ settings.master_db_ip }}'
 DB_PORT        = 3306
 
-KAFKA_PRODUCER   = 'kafka-pub:29092'
-KAFKA_PASSWORD   = '{{ settings.kafka_password }}'
+PUBLIC_KAFKA_PRODUCER   = 'kafka-pub:29092'
+PUBLIC_KAFKA_PASSWORD   = '{{ settings.kafka_password }}'
+
+INTERNAL_KAFKA_PRODUCER = '{{ settings.kafka_producer }}:9092'
+ANNOTATION_TOPIC_OUT    = 'ztf_annotations'
 
 DATA_UPLOAD_MAX_MEMORY_SIZE = 26214400
 

--- a/src/lasair-webapp/lasair/lasair/templates/annotators.html
+++ b/src/lasair-webapp/lasair/lasair/templates/annotators.html
@@ -1,0 +1,22 @@
+{% extends "base.html"%}
+{% block content %}
+
+<div class="row">
+<p>
+An annotator adds extra information, called annotations to Lasair objects.
+</p>
+
+<div class="col-xs-12">
+<h3>Annotators</h3>
+<ul>
+{% for ann in annotators %}
+<li><b>{{ ann.topic }}</b><br/>
+	{{ ann.description | safe }}<br/>
+	<i>responsible user: {{ ann.usersname }}</i>
+</li>
+{% endfor %}
+</ul>
+</div>
+</div>
+
+{% endblock %}

--- a/src/lasair-webapp/lasair/lasair/templates/explore.html
+++ b/src/lasair-webapp/lasair/lasair/templates/explore.html
@@ -21,6 +21,10 @@
   <li>  <a href=/query/>Make a Query</a>
   <li>  <a href=/schema>Table schemas</a>
   </ul>
+<li>Annotators
+  <ul>
+  <li> <a href=/annotators/>List of annotators</a>
+  </ul>
 <li>Watchlists and Areas
   <ul>
   <li>  <a href=/watchlist_new/>Make a Watchlist</a>

--- a/src/lasair-webapp/lasair/lasair/templates/queryform.html
+++ b/src/lasair-webapp/lasair/lasair/templates/queryform.html
@@ -5,9 +5,8 @@
 <script src="//code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
 <script src="/lasair/static/js/query.js"></script>
 
+<div class="row"> <font color='green'>{{ message | safe}}</font> </div>
 <div class="row">
-<font color='green'>{{ message | safe}}</font>
-<hr/>
 <h3>Query Builder</h3>
 The form below is a builder for SQL SELECT queries on the ZTF database of objects. 
 If you are logged in to Lasair, you can name and save your query, 
@@ -82,6 +81,8 @@ Note that the button "Save this Query" below will erase the exiting stream log.
 Click here for <a href=/streams/{{ topic }}>existing stream log</a>.
 {% endif %}
 <hr/>
+<input name='query_name' type='hidden' value='{{ myquery.name }}'/>
+<input name='mq_id' type='hidden' value='{{ myquery.mq_id }}'/>
 
 <!-- run, save or edit this query -->
 {% if new or is_owner %}
@@ -204,7 +205,8 @@ function ConfirmSave()
 {% if newandloggedin or is_owner %}
 <td>
 <input type="submit" class="button" style="color: blue; background-color: #EEEEFF;" 
-value=" Save query" value=" Save this Query" Onclick="ConfirmSave()">
+value=" Save query" value=" Save this Query" 
+{% if myquery.active == 2 %}Onclick="ConfirmSave(){% endif %}">
 </td>
 {% endif %} <!-- newandloggedin or is_owner -->
 

--- a/src/lasair-webapp/lasair/lasair/templates/runquery.html
+++ b/src/lasair-webapp/lasair/lasair/templates/runquery.html
@@ -4,7 +4,7 @@
 <div class="row">
 	<div class="col-sm">
 		<div class="alert alert-primary" role="alert">
-			<p> Showing results for query:</p>
+			<h2> <a href=/query/{{ mq_id }}/>{{ query_name }}</a></h2>
 			<small><samp>{{message}}</samp></small>
 		</div>		
 	</div>

--- a/src/lasair-webapp/lasair/lasair/topic_refresh.py
+++ b/src/lasair-webapp/lasair/lasair/topic_refresh.py
@@ -19,7 +19,7 @@ def connect_db():
 
 def datetime_converter(o):
 # used by json encoder when it gets a type it doesn't understand
-    if isinstance(o, datetime.datetime):
+    if isinstance(o, datetime):
         return o.__str__()
 
 def topic_refresh(real_sql, topic, limit=10):

--- a/src/lasair-webapp/lasair/lasair/topic_refresh.py
+++ b/src/lasair-webapp/lasair/lasair/topic_refresh.py
@@ -43,11 +43,11 @@ def topic_refresh(real_sql, topic, limit=10):
         recent.append(recorddict)
 
     conf = {
-        'bootstrap.servers': lasair.settings.KAFKA_PRODUCER,
+        'bootstrap.servers': lasair.settings.PUBLIC_KAFKA_PRODUCER,
         'security.protocol': 'SASL_PLAINTEXT',
         'sasl.mechanisms'  : 'SCRAM-SHA-256',
         'sasl.username'    : 'admin',
-        'sasl.password'    : lasair.settings.KAFKA_PASSWORD
+        'sasl.password'    : lasair.settings.PUBLIC_KAFKA_PASSWORD
     }
 
     # delete the old topic

--- a/src/lasair-webapp/lasair/lasair/urls.py
+++ b/src/lasair-webapp/lasair/lasair/urls.py
@@ -69,6 +69,8 @@ urlpatterns = [
     path('query/',                  queries.new_myquery,        name='new_myquery'),
     path('query/<int:mq_id>/',      queries.show_myquery,       name='show_myquery'),
 
+    path('annotators/',            views.annotators,          name='annotators'),
+
     path('runquery/',               queries.runquery_post,      name='runquery_post'),
     path('runquery/<int:mq_id>/',   queries.runquery_db,        name='runquery_db'),
 

--- a/src/lasair-webapp/lasair/lasair/views.py
+++ b/src/lasair-webapp/lasair/lasair/views.py
@@ -4,7 +4,7 @@ from django.template.context_processors import csrf
 from django.views.decorators.csrf import csrf_exempt
 from django.db import connection
 from django.db.models import Q
-from lasair.models import Myqueries
+from lasair.models import Myqueries, Annotators
 import lasair.settings
 import mysql.connector
 import json
@@ -318,3 +318,16 @@ def streams(request, topic):
     table = json.loads(data)['digest']
     n = len(table)
     return render(request, 'streams.html', {'topic':topic, 'n':n, 'table':table})
+
+def annotators(request):
+    anns = Annotators.objects.filter().order_by('topic')
+    annotators = []
+    for a in anns:
+        d = {
+            'usersname'  :a.user.first_name +' '+ a.user.last_name,
+            'topic'       :a.topic,
+            'description':a.description
+        }
+        annotators.append(d)
+
+    return render(request, 'annotators.html', {'annotators': annotators})

--- a/src/lasair-webapp/lasair/lasairapi/serializers.py
+++ b/src/lasair-webapp/lasair/lasairapi/serializers.py
@@ -380,6 +380,7 @@ class AnnotateSerializer(serializers.Serializer):
             if row['user'] == userId.id:
                 is_owner = True
                 active = row['active']
+
         if nrow == 0:
             return {'error':"Annotator error: topic %s does not exist" % topic}
         if not is_owner:

--- a/src/lasair-webapp/lasair/lasairapi/serializers.py
+++ b/src/lasair-webapp/lasair/lasairapi/serializers.py
@@ -344,9 +344,9 @@ class AnnotateSerializer(serializers.Serializer):
     objectId       = serializers.CharField(max_length=256, required=True)
     classification = serializers.CharField(max_length=256, required=True)
     version        = serializers.CharField(max_length=256, required=True)
-    explanation    = serializers.CharField(max_length=256, required=True, allow_blank=True)
-    classdict      = serializers.CharField(max_length=256, required=True)
-    url            = serializers.CharField(max_length=256, required=True, allow_blank=True)
+    explanation    = serializers.CharField(max_length=1024, required=True, allow_blank=True)
+    classdict      = serializers.CharField(max_length=4096, required=True)
+    url            = serializers.CharField(max_length=1024, required=True, allow_blank=True)
 
     def save(self):
         topic          = self.validated_data['topic']

--- a/src/lasair-webapp/lasair/lasairapi/serializers.py
+++ b/src/lasair-webapp/lasair/lasairapi/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from gkutils.commonutils import coneSearchHTM, FULL, QUICK, CAT_ID_RA_DEC_COLS, base26, Struct
+from confluent_kafka import Producer, KafkaError
 from datetime import datetime
 from django.db import connection
 from django.db import IntegrityError
@@ -378,10 +379,13 @@ class AnnotateSerializer(serializers.Serializer):
             nrow += 1
             if row['user'] == userId.id:
                 is_owner = True
+                active = row['active']
         if nrow == 0:
             return {'error':"Annotator error: topic %s does not exist" % topic}
         if not is_owner:
             return {'error':"Annotator error: %s is not allowed to submit to topic %s" % (user_name, topic)}
+        if active == 0:
+            return {'error':"Annotator error: topic %s is not active -- ask Lasair team" % topic}
 
         # form the insert query
         query = 'REPLACE INTO annotations ('
@@ -398,5 +402,22 @@ class AnnotateSerializer(serializers.Serializer):
         except mysql.connector.Error as e:
             return {'error':"Query failed %d: %s\n" % (e.args[0], e.args[1])}
 
-        result = {'status': 'success', 'query':query}
-        return result
+        if active < 2:
+            return {'status': 'success', 'query':query}
+
+        # when active=2, we push a kafka message to make sure queries are run immediately
+        message = {'objectId': objectId, 'annotator':topic}
+        conf = {
+            'bootstrap.servers': lasair.settings.INTERNAL_KAFKA_PRODUCER,
+            'client.id': 'client-1',
+        }
+        producer = Producer(conf)
+        topicout = lasair.settings.ANNOTATION_TOPIC_OUT
+        try:
+            s = json.dumps(message)
+            producer.produce(topicout, s)
+        except Exception as e:
+            return {'error':"Kafka production failed: %s\n" % e}
+        producer.flush()
+
+        return {'status': 'success', 'query':query, 'annotation_topic':topicout, 'message':s}


### PR DESCRIPTION
The API for annotations is modified where the annotator is a 'fast' one, i.e. active=2. In this case each annotation also causes a kafka record in ztf_annotations with the objectId and annotator topic.

Three other matters are wrapped in: the database port number comes from Vault and into settings.py;  there is a link back from the results of a query to the definition of the query; and there is a page with all the annotation definitions.